### PR TITLE
Add USB MJPEG webcam display script

### DIFF
--- a/usb_cam_mjpeg.py
+++ b/usb_cam_mjpeg.py
@@ -1,0 +1,42 @@
+import argparse
+import cv2
+
+
+def gstreamer_pipeline(device='/dev/video0', width=1280, height=720, framerate=30):
+    return (
+        f"v4l2src device={device} ! "
+        f"image/jpeg, width={width}, height={height}, framerate={framerate}/1 ! "
+        "jpegdec ! nvvidconv ! video/x-raw, format=BGRx ! videoconvert ! video/x-raw, format=BGR ! appsink"
+    )
+
+
+def display_camera(device='/dev/video0', width=1280, height=720, framerate=30):
+    pipeline = gstreamer_pipeline(device, width, height, framerate)
+    cap = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+    if not cap.isOpened():
+        raise RuntimeError(f"Unable to open camera {device}")
+
+    window = 'USB MJPEG Camera'
+    cv2.namedWindow(window, cv2.WINDOW_AUTOSIZE)
+
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            cv2.imshow(window, frame)
+            if cv2.waitKey(1) & 0xFF == 27:  # ESC key
+                break
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Display MJPEG stream from USB camera using OpenCV')
+    parser.add_argument('--device', default='/dev/video0', help='V4L2 device path')
+    parser.add_argument('--width', type=int, default=1280, help='Capture width')
+    parser.add_argument('--height', type=int, default=720, help='Capture height')
+    parser.add_argument('--framerate', type=int, default=30, help='Frame rate')
+    args = parser.parse_args()
+    display_camera(args.device, args.width, args.height, args.framerate)


### PR DESCRIPTION
## Summary
- Add Python script to display MJPEG stream from a USB webcam on Jetson devices using JetPack's OpenCV and GStreamer

## Testing
- `python -m py_compile usb_cam_mjpeg.py`


------
https://chatgpt.com/codex/tasks/task_e_68b20d80ea58832a88832d054ea1bd86