### PR TITLE
Add GStreamer fallback for internal stream errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repository contains a minimal Python example that displays video
 from a USB camera which delivers MJPEG frames. The stream is decoded and
 shown using a GStreamer pipeline and OpenCV. It is intended for use on
 NVIDIA Jetson devices but should work on any Linux system with GStreamer
-and a supported camera.
+and a supported camera. If the GStreamer pipeline cannot be opened or
+produces an internal data stream error while running, the script
+automatically falls back to a direct V4L2 capture to keep the stream
+running.
 
 ## Requirements
 

--- a/usb_cam_mjpeg.py
+++ b/usb_cam_mjpeg.py
@@ -13,8 +13,14 @@ def gstreamer_pipeline(device='/dev/video0', width=1280, height=720, framerate=3
 def display_camera(device='/dev/video0', width=1280, height=720, framerate=30):
     pipeline = gstreamer_pipeline(device, width, height, framerate)
     cap = cv2.VideoCapture(pipeline, cv2.CAP_GSTREAMER)
+    fallback = False
     if not cap.isOpened():
-        raise RuntimeError(f"Unable to open camera {device}")
+        # Fallback to a direct V4L2 capture if the GStreamer pipeline fails to open
+        print("GStreamer pipeline failed, falling back to V4L2 capture")
+        cap = cv2.VideoCapture(device)
+        if not cap.isOpened():
+            raise RuntimeError(f"Unable to open camera {device}")
+        fallback = True
 
     window = 'USB MJPEG Camera'
     cv2.namedWindow(window, cv2.WINDOW_AUTOSIZE)
@@ -23,6 +29,15 @@ def display_camera(device='/dev/video0', width=1280, height=720, framerate=30):
         while True:
             ret, frame = cap.read()
             if not ret:
+                if not fallback:
+                    # Try switching to direct capture once on internal data stream error
+                    print("GStreamer read failed, falling back to V4L2 capture")
+                    cap.release()
+                    cap = cv2.VideoCapture(device)
+                    fallback = True
+                    if not cap.isOpened():
+                        raise RuntimeError(f"Unable to open camera {device}")
+                    continue
                 break
             cv2.imshow(window, frame)
             if cv2.waitKey(1) & 0xFF == 27:  # ESC key


### PR DESCRIPTION
## Summary
- handle GStreamer internal stream errors by switching to a direct V4L2 capture fallback
- document automatic fallback behavior in README

## Testing
- `python -m py_compile usb_cam_mjpeg.py`
- `python usb_cam_mjpeg.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b2203115d0832ab0d030c6934ae0f3